### PR TITLE
Cascade deletion of contacts

### DIFF
--- a/managed/EckEntityType__Eck_Hiorg_Education.mgd.php
+++ b/managed/EckEntityType__Eck_Hiorg_Education.mgd.php
@@ -100,6 +100,7 @@ return [
         'filter' => 'contact_type=Individual',
         'in_selector' => FALSE,
         'fk_entity' => 'Contact',
+        'fk_entity_on_delete' => 'cascade',
       ],
       'match' => [
         'custom_group_id',

--- a/managed/EckEntityType__Eck_Hiorg_Qualification.mgd.php
+++ b/managed/EckEntityType__Eck_Hiorg_Qualification.mgd.php
@@ -78,6 +78,7 @@ return [
         'filter' => 'contact_type=Individual',
         'in_selector' => FALSE,
         'fk_entity' => 'Contact',
+        'fk_entity_on_delete' => 'cascade',
       ],
       'match' => [
         'custom_group_id',

--- a/managed/EckEntityType__Eck_Hiorg_Verification.mgd.php
+++ b/managed/EckEntityType__Eck_Hiorg_Verification.mgd.php
@@ -78,6 +78,7 @@ return [
         'filter' => 'contact_type=Individual',
         'in_selector' => FALSE,
         'fk_entity' => 'Contact',
+        'fk_entity_on_delete' => 'cascade',
       ],
       'match' => [
         'custom_group_id',


### PR DESCRIPTION
This makes use of the functionality added in https://github.com/civicrm/civicrm-core/pull/28225 to cascade contact deletion.

When creating/updating entities APIv4 ignores values not defined `getFields`. So it can be used on Civi installation where the new functionality is not available, yet.

systopia-reference: 22817